### PR TITLE
fix(languages): Make grock aware of .cson files

### DIFF
--- a/lib/languages.coffee
+++ b/lib/languages.coffee
@@ -45,7 +45,7 @@ module.exports = LANGUAGES =
     foldPrefix:        '^'
 
   'CoffeeScript':
-    nameMatchers:      ['.coffee', 'Cakefile']
+    nameMatchers:      ['.coffee', '.cson', 'Cakefile']
     pygmentsLexer:     'coffee-script'
     highlightJS:       'coffeescript'
     # **CoffeScript's multi-line block-comment styles.**


### PR DESCRIPTION
Would love to have `*.cson` files documented (parsed).
