### PR TITLE
Fix `whitspace-after-token` option being ignored

### DIFF
--- a/bin/grock
+++ b/bin/grock
@@ -79,7 +79,7 @@ var optimist = require('optimist')
   .describe('root', "The project's root directory")
 
   .boolean('whitespace-after-token')
-  .default('whitespace-after-token', projectConfig['whitespace-after-token'] || true)
+  .default('whitespace-after-token', projectConfig['whitespace-after-token'] === undefined ? true : projectConfig['whitespace-after-token'])
   .describe('whitespace-after-token', 'Require whitespace after a comment token for a line to be considered a comment')
 
   .string('repository-url')


### PR DESCRIPTION
If `projectConfig['whitespace-after-token']` is intentionally set to false then `projectConfig['whitespace-after-token'] || true` will evaluate to true. Correct behavior would be to only use the default if `projectConfig['whitespace-after-token']` is unset/undefined.
