### PR TITLE
Fix Handlebars/Mustache support

### DIFF
--- a/lib/utils/seperator.coffee
+++ b/lib/utils/seperator.coffee
@@ -308,7 +308,7 @@ module.exports = (data='', language=languages.JavaScript, options={}) ->
     # However, we treat all comments beginning with } as inline code commentary
     # and comments starting with ^ cause that comment and the following code
     # block to start folded.
-    else if (match = line.match aSingleLine)?
+    else if aSingleLine? and (match = line.match aSingleLine)?
 
       # Uses `match` as a placeholder.
       [match, comment] = match


### PR DESCRIPTION
Handlebars and Mustache templates don't support single line comments. When grock creates docs for them, all of the code is removed from the output. Changing this one line fixes that by checking for the existence of `aSingleLine` before looking for a match.
